### PR TITLE
Add basic Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Based on https://github.com/SciTools/conda-gitenv/blob/master/.travis.yml
+language: python
+
+sudo: false
+
+env:
+    global:
+       - CONDA_INSTALL_LOCN="${HOME}/conda"
+
+    matrix:
+        - PYTHON=3.6
+
+install:
+    - mkdir -p ${HOME}/cache/pkgs
+    - "[ ! -f ${HOME}/cache/miniconda.sh ] && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${HOME}/cache/miniconda.sh || :"
+    - bash ${HOME}/cache/miniconda.sh -b -p ${CONDA_INSTALL_LOCN} && export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
+
+    # Re-use the pacakges in the cache, and download any new ones into that location.
+    - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
+
+    # Now do the things we need to do to install it.
+    - conda install --file requirements.txt python=${PYTHON} --yes --quiet -c conda-forge
+
+script:
+    # Currently we tests only preparing data for analysis 
+    - make data
+
+
+# We store the files that are downloaded from continuum.io, but not the environments that are created.
+cache:
+    directories:
+      - $HOME/cache
+before_cache:
+  # Remove all untarred directories.
+  - find $CONDA_INSTALL_LOCN/pkgs/ -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;


### PR DESCRIPTION
Add basic Travis CI - for now only data download is tested. Should be updated accordingly in future PRs to test only data preparation / somehow not retrain all models.